### PR TITLE
Resolve GitHub issue number 6

### DIFF
--- a/jira_mcp/tools/issues.py
+++ b/jira_mcp/tools/issues.py
@@ -21,9 +21,9 @@ def format_issue(issue: dict[str, Any]) -> str:
     fields = issue.get("fields", {})
     key = issue.get("key", "N/A")
     summary = fields.get("summary", "N/A")
-    status = fields.get("status", {}).get("name", "N/A")
-    issue_type = fields.get("issuetype", {}).get("name", "N/A")
-    assignee = fields.get("assignee", {}).get("displayName", "Unassigned")
+    status = (fields.get("status") or {}).get("name", "N/A")
+    issue_type = (fields.get("issuetype") or {}).get("name", "N/A")
+    assignee = (fields.get("assignee") or {}).get("displayName", "Unassigned")
     description = fields.get("description", "No description")
 
     # Handle Atlassian Document Format (ADF) for description
@@ -88,7 +88,7 @@ def format_search_results(results: dict[str, Any]) -> str:
         fields = issue.get("fields", {})
         key = issue.get("key", "N/A")
         summary = fields.get("summary", "N/A")
-        status = fields.get("status", {}).get("name", "N/A")
+        status = (fields.get("status") or {}).get("name", "N/A")
 
         output += f"- **{key}**: {summary} [{status}]\n"
 


### PR DESCRIPTION
Resolves #6: jira_get_issue fails with NoneType error when fields are null

When JIRA API responses contain explicit null values for fields like status, issuetype, or assignee, the original code using `fields.get("field", {})` would return None (the actual value) instead of the default empty dict, causing subsequent `.get()` calls to fail.

Changed to use null-coalescing pattern `(fields.get("field") or {})` which correctly handles both missing keys AND explicit None values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when displaying issues with missing or null fields, ensuring default values (such as "Unassigned" for assignee) are consistently shown instead of causing errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->